### PR TITLE
Update composer and fix initial issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea/
 vendor/
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "rg/avro-php",
-    "description": "Composer packaging for vanilla Apache Avro, with fixes",
+    "name": "flix-tech/avro-php",
+    "description": "Avro schema encoder/decoder. Fork of rg/avro-php",
     "license": "Apache-2.0",
     "require": {
         "php": ">=5.5.0"

--- a/lib/avro/datum.php
+++ b/lib/avro/datum.php
@@ -946,7 +946,7 @@ class AvroIOBinaryDecoder
   protected function skip_long()
   {
     $b = $this->next_byte();
-    while (0 != ($b & 0x80))
+    while ($b == '' || 0 != ($b & 0x80))
       $b = $this->next_byte();
   }
 

--- a/lib/avro/io.php
+++ b/lib/avro/io.php
@@ -202,8 +202,10 @@ class AvroStringIO extends AvroIO
   {
     $this->check_closed();
     $read='';
-    for($i=$this->current_index; $i<($this->current_index+$len); $i++) 
+    for($i=$this->current_index; $i<($this->current_index+$len); $i++){
+      if(!isset($this->string_buffer[$i])) continue;
       $read .= $this->string_buffer[$i];
+    }
     if (strlen($read) < $len)
       $this->current_index = $this->length();
     else


### PR DESCRIPTION
This fixes the problem with `Unitialized string offset` which caused the decoding of avro scheas containing an array fail. It also adds a fix from another fork `rdblue/avro-php`, and initializes composer.