### PR TITLE
Ensured null default is normalized

### DIFF
--- a/lib/avro/schema.php
+++ b/lib/avro/schema.php
@@ -1431,7 +1431,7 @@ class AvroField extends AvroSchema
     $avro[AvroSchema::TYPE_ATTR] = ($this->is_type_from_schemata)
       ? $this->type->qualified_name() : $this->type->to_avro();
 
-    if (isset($this->default))
+    if ($this->has_default)
       $avro[AvroField::DEFAULT_ATTR] = $this->default;
 
     if ($this->order)


### PR DESCRIPTION
I encountered an incompatible error when upgrading a schema using `"flix-tech/avro-serde-php": "^1.1"`, whereas the upgrade was totally fine when performing it through curl.

It appears that this is related to an issue in how the php lib normalizes the schema, and how it normalizes default null value in particular.

Here's an example.

Let's say that this schema is registered under the subject `foo-value`:
```json
{
  "type": "record",
  "name": "foo",
  "namespace": "com.landoop",
  "fields": [
    {
      "name": "name",
      "type": "string"
    }
  ]
}
```

If I register the following new version, it should work (because it is backward compatible):
```json
{
  "type": "record",
  "name": "foo",
  "namespace": "com.landoop",
  "fields": [
    {
      "name": "name",
      "type": "string"
    },
    {
      "name": "email",
      "type": ["null", "string"],
      "default": null
    }
  ]
}
```

But it fails, with the following error:
```
Fatal error: Uncaught FlixTech\SchemaRegistryApi\Exception\IncompatibleAvroSchemaException: Schema being registered is incompatible with an earlier schema in /app/vendor/flix-tech/confluent-schema-registry-api/s
rc/Exception/ExceptionMap.php on line 95
```

I discovered that the posted payload is not the one that I provided to the `AvroSchema::parse` method, but it is stripped from all default values!

After investigation, it appears that the error lies in how the fields are normalized back, null default values will be ignored and the schema registry sees that as a BC break.

The PR specifically fixes this issue.

What I don't understand is that, as the `email` field is an `union` type, its **default** default value should be the one of the first schema[1], here being `"null"` (which default value is `null`), so it shouldn't be necessary to specify this default value.

Maybe the error lies in the schema registry after all? :thinking: 

EDIT: I'm running [confluentinc/cp-schema-registry:5.0.0-1](https://hub.docker.com/r/confluentinc/cp-schema-registry/)

[1]  Default values for union fields correspond to the first schema in the union. https://avro.apache.org/docs/1.8.1/spec.html#schema_complex