### PR TITLE
Fix method visibility

### DIFF
--- a/lib/avro/datum.php
+++ b/lib/avro/datum.php
@@ -1015,7 +1015,7 @@ class AvroIOBinaryDecoder
 
   public function skip_int() { return $this->skip_long(); }
 
-  protected function skip_long()
+  public function skip_long()
   {
     $b = ord($this->next_byte());
     while ('' == $b || 0 != ($b & 0x80))


### PR DESCRIPTION
The method AvroIODatumReader::skip_data calls the
AvroIOBinaryDecoder::skip_long method, which is protected. The result is
a fatal error.

Change the AvroIOBinaryDecoder::skip_long method visibility from
protected to public as all the others skip_* methods.